### PR TITLE
Refactor task deletion into `TaskList` and clean up `AddCommand`

### DIFF
--- a/src/main/java/luna/command/AddCommand.java
+++ b/src/main/java/luna/command/AddCommand.java
@@ -17,42 +17,74 @@ public class AddCommand extends Command {
     /**
      * Constructs an AddCommand based on user input.
      *
-     * @param input The raw user input.
+     * @param input The raw user input containing the task type and description.
      * @throws LunaException If the input format is invalid.
      */
     public AddCommand(String input) throws LunaException {
         String[] parts = input.split(" ", 2);
-        String[] details = parts.length > 1 ? parts[1].split(" /by | /from | /to ", 3) : new String[0];
 
-        switch (parts[0]) {
-        case "todo":
-            if (details.length < 1 || details[0].trim().isEmpty()) {
-                throw new LunaException(LunaException.ErrorType.INVALID_FORMAT, "Correct format: `todo <description>`");
-            }
-            task = new Todo(details[0]);
-            break;
-        case "deadline":
-            if (details.length < 2 || details[0].trim().isEmpty() || details[1].trim().isEmpty()) {
-                throw new LunaException(
-                        LunaException.ErrorType.INVALID_FORMAT,
-                        "Correct format: `deadline <description> /by <dd/mm/yyyy>`"
-                );
-            }
-            task = new Deadline(details[0], details[1]);
-            break;
-        case "event":
-            if (details.length < 3 || details[0].trim().isEmpty() || details[1].trim().isEmpty()
-                        || details[2].trim().isEmpty()) {
-                throw new LunaException(
-                        LunaException.ErrorType.INVALID_FORMAT,
-                        "Correct format: `event <description> /from <dd/mm/yyyy> /to <dd/mm/yyyy>`"
-                );
-            }
-            task = new Event(details[0], details[1], details[2]);
-            break;
-        default:
-            throw new LunaException(LunaException.ErrorType.UNKNOWN_COMMAND, "");
+        if (parts.length < 2 || parts[1].trim().isEmpty()) {
+            throw new LunaException(LunaException.ErrorType.INVALID_FORMAT, "Task description cannot be empty.");
         }
+
+        String[] details = parts[1].split(" /by | /from | /to ", 3);
+        this.task = createTask(parts[0], details);
+    }
+
+    /**
+     * Creates a Task object based on the specified task type and details.
+     *
+     * @param taskType The type of task (e.g., "todo", "deadline", "event").
+     * @param details  The task details, including description and date (if applicable).
+     * @return A Task object of the appropriate type.
+     * @throws LunaException If the task type is invalid or the details are incorrectly formatted.
+     */
+    private Task createTask(String taskType, String[] details) throws LunaException {
+        switch (taskType.toLowerCase()) {
+        case "todo" -> {
+            validateDetails(details, 1, "todo <description>");
+            return new Todo(details[0]);
+        }
+        case "deadline" -> {
+            validateDetails(details, 2, "deadline <description> /by <dd/mm/yyyy>");
+            return new Deadline(details[0], details[1]);
+        }
+        case "event" -> {
+            validateDetails(details, 3, "event <description> /from <dd/mm/yyyy> /to <dd/mm/yyyy>");
+            return new Event(details[0], details[1], details[2]);
+        }
+        default -> throw new LunaException(LunaException.ErrorType.UNKNOWN_COMMAND, "Invalid command.");
+        }
+    }
+
+    /**
+     * Validates that the provided details contain the required number of fields.
+     *
+     * @param details        The array of details extracted from user input.
+     * @param requiredLength The minimum number of required details for the task type.
+     * @param correctFormat  The correct format of the command, used in error messages.
+     * @throws LunaException If the details array has missing or empty fields.
+     */
+    private void validateDetails(String[] details, int requiredLength, String correctFormat) throws LunaException {
+        if (details.length < requiredLength || anyEmpty(details, requiredLength)) {
+            throw new LunaException(LunaException.ErrorType.INVALID_FORMAT, "Correct format: `" + correctFormat + "`");
+        }
+    }
+
+    /**
+     * Checks whether any of the required details are empty.
+     *
+     * @param details The array of task details.
+     * @param count   The number of fields to check for emptiness.
+     * @return true if any required detail is empty, false otherwise.
+     */
+    private boolean anyEmpty(String[] details, int count) {
+        for (int i = 0; i < count; i++) {
+            if (details[i].trim().isEmpty()) {
+                return true;
+            }
+        }
+        return false;
     }
 
     @Override

--- a/src/main/java/luna/command/DeleteCommand.java
+++ b/src/main/java/luna/command/DeleteCommand.java
@@ -58,10 +58,7 @@ public class DeleteCommand extends Command {
             storage.saveTasks(tasks.getTasks());
             return "Oki~ I've removed all tasks!\nNow you have 0 tasks left in the list~";
         } else {
-            if (index < 0 || index >= tasks.getTasks().size()) {
-                throw new LunaException(LunaException.ErrorType.INVALID_TASK_NUMBER, "");
-            }
-            Task removedTask = tasks.getTasks().remove((int) index);
+            Task removedTask = tasks.deleteTask(index);
             storage.saveTasks(tasks.getTasks());
             return "Oki~ I've removed this task!:\n" + removedTask
                            + "\nNow you have " + tasks.getTasks().size() + " tasks left in the list~";

--- a/src/main/java/luna/task/TaskList.java
+++ b/src/main/java/luna/task/TaskList.java
@@ -1,6 +1,7 @@
 package luna.task;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
 import luna.LunaException;
@@ -46,16 +47,14 @@ public class TaskList {
      * Deletes a task at the specified index.
      *
      * @param index The index of the task to be deleted (0-based).
-     * @return A message confirming the deletion.
+     * @return The deleted task.
      * @throws LunaException If the index is out of bounds.
      */
-    public String deleteTask(int index) throws LunaException {
+    public Task deleteTask(int index) throws LunaException {
         if (index < 0 || index >= tasks.size()) {
             throw new LunaException(LunaException.ErrorType.INVALID_TASK_NUMBER, "");
         }
-        Task removedTask = tasks.remove(index);
-        return "Oki~ I've removed this task!:\n" + removedTask
-                       + "\nNow you have " + tasks.size() + " tasks left in the list~";
+        return tasks.remove(index);
     }
 
     /**
@@ -95,17 +94,12 @@ public class TaskList {
      * @return A message listing the found tasks.
      */
     public String findTasks(String... keywords) {
-        List<Task> matchingTasks = new ArrayList<>();
-
-        for (Task task : tasks) {
-            String description = task.getDescription().toLowerCase();
-            for (String keyword : keywords) {
-                if (description.contains(keyword)) {
-                    matchingTasks.add(task);
-                    break;
-                }
-            }
-        }
+        List<Task> matchingTasks = tasks.stream()
+                                           .filter(task -> {
+                                               String description = task.getDescription().toLowerCase();
+                                               return Arrays.stream(keywords).anyMatch(description::contains);
+                                           })
+                                           .toList();
 
         if (matchingTasks.isEmpty()) {
             return "No matching tasks found!";
@@ -113,8 +107,9 @@ public class TaskList {
 
         StringBuilder result = new StringBuilder("Here are the matching tasks in your list:\n");
         for (int i = 0; i < matchingTasks.size(); i++) {
-            result.append((i + 1)).append(". ").append(matchingTasks.get(i)).append("\n");
+            result.append(i + 1).append(". ").append(matchingTasks.get(i)).append("\n");
         }
+
         return result.toString().trim();
     }
 


### PR DESCRIPTION
Task deletion logic reside in `DeleteCommand` instead of `TaskList`, which is inconsistent as it currently encapsulates `AddCommand`. `AddCommand` contain deep nesting.

The inconsistency reduce code quality and maintainability. Deep nesting and repetitive validation logic reduces readability.

Let's:
- Move the deletion logic into `TaskList` to ensure both adding and deleting tasks are handled within the same class.
- Let's refactor `AddCommand` by introducing helper methods to validate inputs, reducing deep nesting and improving readability.

This improves cohesion in `TaskList`, makes command classes cleaner, and enhances maintainability by following a consistent structure for task management.