### PR TITLE
Add `TagCommand` to Luna

### DIFF
--- a/config/checkstyle/checkstyle.xml
+++ b/config/checkstyle/checkstyle.xml
@@ -37,6 +37,12 @@
   <!-- All Java AST specific tests live under TreeWalker module. -->
   <module name="TreeWalker">
 
+    <!-- Suppresses indentation check for lambda-style switch statements -->
+    <module name="SuppressionXpathSingleFilter">
+      <property name="checks" value="Indentation"/>
+      <property name="query" value="//SWITCH_RULE/descendant-or-self::node()"/>
+    </module>
+
     <!-- Required to allow exceptions in code style -->
     <module name="SuppressionCommentFilter">
       <property name="offCommentFormat" value="CHECKSTYLE.OFF\: ([\w\|]+)"/>

--- a/src/main/java/luna/Parser.java
+++ b/src/main/java/luna/Parser.java
@@ -8,6 +8,7 @@ import luna.command.ExitCommand;
 import luna.command.FindCommand;
 import luna.command.ListCommand;
 import luna.command.MarkCommand;
+import luna.command.TagCommand;
 import luna.command.UnmarkCommand;
 
 /**
@@ -39,6 +40,8 @@ public class Parser {
             return new DeleteCommand(userInput);
         case "find":
             return new FindCommand(userInput);
+        case "tag":
+            return new TagCommand(userInput);
         case "bye":
             return new ExitCommand();
         default:

--- a/src/main/java/luna/command/TagCommand.java
+++ b/src/main/java/luna/command/TagCommand.java
@@ -1,0 +1,41 @@
+package luna.command;
+
+import luna.LunaException;
+import luna.storage.Storage;
+import luna.task.TaskList;
+
+/**
+ * Handles tagging tasks in the task list.
+ */
+public class TagCommand extends Command {
+    private final int index;
+    private final String tag;
+
+    /**
+     * Constructs a TagCommand.
+     *
+     * @param input User input containing the command, task number, and tag.
+     * @throws LunaException If the input format is invalid.
+     */
+    public TagCommand(String input) throws LunaException {
+        try {
+            String[] parts = input.split(" ", 3);
+            if (parts.length < 3 || parts[2].trim().isEmpty()) {
+                throw new LunaException(LunaException.ErrorType.INVALID_FORMAT,
+                        "Correct format for tagging is `tag <task number> <tag>`");
+            }
+            this.index = Integer.parseInt(parts[1]) - 1;
+            this.tag = parts[2].trim();
+        } catch (NumberFormatException e) {
+            throw new LunaException(LunaException.ErrorType.INVALID_FORMAT,
+                    "Correct format for tagging is `tag <task number> <tag>`");
+        }
+    }
+
+    @Override
+    public String executeAndReturn(TaskList tasks, Storage storage) throws LunaException {
+        tasks.addTag(index, tag);
+        storage.saveTasks(tasks.getTasks());
+        return "Oki~ I've added the tag `" + tag + "` to this task:\n" + tasks.getTasks().get(index);
+    }
+}

--- a/src/main/java/luna/task/Deadline.java
+++ b/src/main/java/luna/task/Deadline.java
@@ -63,7 +63,8 @@ public class Deadline extends Task {
      */
     @Override
     public String toString() {
-        return "[D][" + getStatusIcon() + "] " + description + " (by: " + by.format(OUTPUT_FORMATTER) + ")";
+        return "[D][" + getStatusIcon() + "] " + description
+                       + " (by: " + by.format(OUTPUT_FORMATTER) + ")" + tagToString();
     }
 
     /**
@@ -73,6 +74,9 @@ public class Deadline extends Task {
      */
     @Override
     public String toFileFormat() {
-        return "D | " + (isDone ? "1" : "0") + " | " + description + " | " + by.format(INPUT_FORMATTER);
+        return "D | " + (isDone ? "1" : "0") + " | "
+                       + (tags.isEmpty() ? " " : String.join(",", tags)) + " | "
+                       + description + " | " + by.format(INPUT_FORMATTER);
     }
+
 }

--- a/src/main/java/luna/task/Event.java
+++ b/src/main/java/luna/task/Event.java
@@ -71,9 +71,10 @@ public class Event extends Task {
      */
     @Override
     public String toString() {
-        return "[E][" + getStatusIcon() + "] " + description + " (from: " + from.format(OUTPUT_FORMATTER)
-                       + " to: " + to.format(OUTPUT_FORMATTER) + ")";
+        return "[E][" + getStatusIcon() + "] " + description + " (from: "
+                       + from.format(OUTPUT_FORMATTER) + " to: " + to.format(OUTPUT_FORMATTER) + ")" + tagToString();
     }
+
 
     /**
      * Converts the event to a string format for file storage.
@@ -82,7 +83,9 @@ public class Event extends Task {
      */
     @Override
     public String toFileFormat() {
-        return "E | " + (isDone ? "1" : "0") + " | " + description + " | "
-                       + from.format(INPUT_FORMATTER) + " | " + to.format(INPUT_FORMATTER);
+        return "E | " + (isDone ? "1" : "0") + " | "
+                       + (tags.isEmpty() ? " " : String.join(",", tags)) + " | "
+                       + description + " | " + from.format(INPUT_FORMATTER) + " | " + to.format(INPUT_FORMATTER);
     }
+
 }

--- a/src/main/java/luna/task/Task.java
+++ b/src/main/java/luna/task/Task.java
@@ -1,18 +1,18 @@
 package luna.task;
 
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+
+import luna.LunaException;
+
 /**
  * Represents a task with a description and completion status.
  */
 public class Task {
-    /**
-     * Description of the task.
-     */
     protected String description;
-
-    /**
-     * Status of the task (done or not).
-     */
     protected boolean isDone;
+    protected Set<String> tags;
 
     /**
      * Constructs a task with a given description.
@@ -22,6 +22,7 @@ public class Task {
     public Task(String description) {
         this.description = description;
         this.isDone = false;
+        this.tags = new HashSet<>();
     }
 
     /**
@@ -57,12 +58,33 @@ public class Task {
     }
 
     /**
+     * Adds a tag to the task.
+     *
+     * @param tag The tag to add.
+     */
+    public void addTag(String tag) {
+        if (tag != null && !tag.trim().isEmpty()) {
+            tags.add(tag.trim());
+        }
+    }
+
+    /**
+     * Returns the tags in a readable format.
+     *
+     * @return A formatted string of tags.
+     */
+    public String tagToString() {
+        return tags.isEmpty() ? "" : " #" + String.join(" #", tags);
+    }
+
+    /**
      * Returns the string representation of the task.
      *
      * @return String format of the task.
      */
+    @Override
     public String toString() {
-        return "[" + getStatusIcon() + "] " + description;
+        return "[" + getStatusIcon() + "] " + description + tagToString();
     }
 
     /**
@@ -71,8 +93,10 @@ public class Task {
      * @return Formatted string representation for saving to file.
      */
     public String toFileFormat() {
-        return "T | " + (isDone ? "1" : "0") + " | " + description;
+        return "T | " + (isDone ? "1" : "0") + " | "
+                       + (tags.isEmpty() ? " " : String.join(",", tags)) + " | " + description;
     }
+
 
     /**
      * Constructs a task from a given file line.
@@ -81,47 +105,88 @@ public class Task {
      * @return The corresponding Task object, or null if the format is incorrect.
      */
     public static Task fromFileFormat(String line) {
-        String[] parts = line.split(" \\| ");
+        String[] parts = line.split(" \\| ", -1); // Preserve empty trailing fields
 
-        if (parts.length < 3) {
+        if (parts.length < 4) {
             System.out.println("Skipping corrupted task (invalid format): " + line);
             return null;
         }
 
-        Task task;
-        try {
-            switch (parts[0]) {
-            case "T":
-                task = new Todo(parts[2]);
-                break;
-            case "D":
-                if (parts.length < 4) {
-                    System.out.println("Skipping corrupted deadline task (missing date): " + line);
-                    return null;
-                }
-                task = new Deadline(parts[2], parts[3]);
-                break;
-            case "E":
-                if (parts.length < 5) {
-                    System.out.println("Skipping corrupted event task (missing dates): " + line);
-                    return null;
-                }
-                task = new Event(parts[2], parts[3], parts[4]);
-                break;
-            default:
-                System.out.println("Skipping unknown task type: " + line);
-                return null;
-            }
+        boolean isDone = "1".equals(parts[1]);
+        String[] tags = parts[2].trim().isEmpty() ? new String[]{} : parts[2].split(",");
 
-            if ("1".equals(parts[1])) {
-                task.mark();
-            }
-
-            System.out.println("Loaded task: " + task); // Debugging log
-            return task;
-        } catch (Exception e) {
-            System.out.println("Skipping corrupted task: " + line);
+        Task task = createTaskFromParts(parts);
+        if (task == null) {
+            System.out.println("Skipping unknown task type: " + line);
             return null;
         }
+
+        if (isDone) {
+            task.mark();
+        }
+
+        for (String tag : tags) {
+            task.addTag(tag.trim());
+        }
+
+        return task;
+    }
+
+    /**
+     * Creates a task based on the given file parts.
+     *
+     * @param parts The parsed file line split into components.
+     * @return The corresponding Task object, or null if invalid.
+     */
+    private static Task createTaskFromParts(String[] parts) {
+        try {
+            return switch (parts[0]) {
+                case "T" -> createTodo(parts);
+                case "D" -> createDeadline(parts);
+                case "E" -> createEvent(parts);
+                default -> null;
+            };
+        } catch (Exception e) {
+            System.out.println("Skipping corrupted task due to exception: " + Arrays.toString(parts));
+            return null;
+        }
+    }
+
+    /**
+     * Creates a Todo task from file parts.
+     *
+     * @param parts The parsed file line split into components.
+     * @return A Todo object.
+     */
+    private static Task createTodo(String[] parts) {
+        return new Todo(parts[3]);
+    }
+
+    /**
+     * Creates a Deadline task from file parts.
+     *
+     * @param parts The parsed file line split into components.
+     * @return A Deadline object, or null if invalid.
+     */
+    private static Task createDeadline(String[] parts) throws LunaException {
+        if (parts.length < 5) {
+            System.out.println("Skipping corrupted deadline task (missing date): " + Arrays.toString(parts));
+            return null;
+        }
+        return new Deadline(parts[3], parts[4]);
+    }
+
+    /**
+     * Creates an Event task from file parts.
+     *
+     * @param parts The parsed file line split into components.
+     * @return An Event object, or null if invalid.
+     */
+    private static Task createEvent(String[] parts) throws LunaException {
+        if (parts.length < 6) {
+            System.out.println("Skipping corrupted event task (missing dates): " + Arrays.toString(parts));
+            return null;
+        }
+        return new Event(parts[3], parts[4], parts[5]);
     }
 }

--- a/src/main/java/luna/task/TaskList.java
+++ b/src/main/java/luna/task/TaskList.java
@@ -145,4 +145,23 @@ public class TaskList {
 
         return result.toString();
     }
+
+    /**
+     * Tags a task at the specified index with the given tag.
+     *
+     * @param index The index of the task to be tagged (0-based).
+     * @param tag   The tag to add.
+     * @throws LunaException If the index is out of bounds or the tag is empty.
+     */
+    public void addTag(int index, String tag) throws LunaException {
+        if (index < 0 || index >= tasks.size()) {
+            throw new LunaException(LunaException.ErrorType.INVALID_TASK_NUMBER, "Invalid task number.");
+        }
+        if (tag == null || tag.trim().isEmpty()) {
+            throw new LunaException(LunaException.ErrorType.INVALID_FORMAT, "Tag cannot be empty.");
+        }
+
+        Task task = tasks.get(index);
+        task.addTag(tag);
+    }
 }

--- a/src/main/java/luna/task/Todo.java
+++ b/src/main/java/luna/task/Todo.java
@@ -31,6 +31,8 @@ public class Todo extends Task {
      */
     @Override
     public String toFileFormat() {
-        return "T | " + (isDone ? "1" : "0") + " | " + description;
+        return "T | " + (isDone ? "1" : "0") + " | "
+                       + (tags.isEmpty() ? " " : String.join(",", tags)) + " | " + description;
     }
+
 }

--- a/src/test/java/luna/task/DeadlineTest.java
+++ b/src/test/java/luna/task/DeadlineTest.java
@@ -14,6 +14,10 @@ class DeadlineTest {
     void toString_correctFormat_success() throws LunaException {
         Deadline deadline = new Deadline("Submit Report", "30/12/2025");
         assertEquals("[D][ ] Submit Report (by: 30 of December 2025)", deadline.toString());
+
+        // Test with tags
+        deadline.addTag("urgent");
+        assertEquals("[D][ ] Submit Report (by: 30 of December 2025) #urgent", deadline.toString());
     }
 
     @Test
@@ -24,5 +28,16 @@ class DeadlineTest {
         } catch (Exception e) {
             assertTrue(e.getMessage().contains("Correct format"));
         }
+    }
+
+    @Test
+    void toFileFormat_validDeadline_correctFormat() throws LunaException {
+        Deadline deadline = new Deadline("Submit Report", "30/12/2025");
+        assertEquals("D | 0 |   | Submit Report | 30/12/2025", deadline.toFileFormat());
+
+        // Test with tags
+        deadline.addTag("important");
+        deadline.addTag("work");
+        assertEquals("D | 0 | important,work | Submit Report | 30/12/2025", deadline.toFileFormat());
     }
 }

--- a/src/test/java/luna/task/TodoTest.java
+++ b/src/test/java/luna/task/TodoTest.java
@@ -10,12 +10,21 @@ class TodoTest {
     void todoCreation_validDescription_success() {
         Todo todo = new Todo("Finish homework");
         assertEquals("[T][ ] Finish homework", todo.toString());
+
+        // Test with tags
+        todo.addTag("school");
+        assertEquals("[T][ ] Finish homework #school", todo.toString());
     }
 
     @Test
     void toFileFormat_validTodo_correctFormat() {
         Todo todo = new Todo("Go jogging");
-        assertEquals("T | 0 | Go jogging", todo.toFileFormat());
+        assertEquals("T | 0 |   | Go jogging", todo.toFileFormat()); // Empty tags should be an empty field
+
+        // Test with tags
+        todo.addTag("exercise");
+        todo.addTag("morning");
+        assertEquals("T | 0 | exercise,morning | Go jogging", todo.toFileFormat());
     }
 
     @Test


### PR DESCRIPTION
Tasks have no tags to visually categorize them easily.

Larger number of tasks may lead to difficulty using the bot.

Let's:
- Add `TagCommand` class to support tagging of tasks.
- modify the `toFileFormat` method in task classes to include tags.
- Update `fromFileFormat` to support loading tasks with tags.
- Refactor `fromFileFormat` to improve readability and code quality.

Adding support of tagging by introducing `TagCommand` ensures consistency of commands and user usage, and refactoring `fromFileFormat` into different methods improves readability and maintainability by reducing the complexity.
`ToFileFormat`ensures tags are saved in the third field to ensure consistency regardless of the task type.